### PR TITLE
Avoid race condition by sending copies of mongo data as op.Data

### DIFF
--- a/gtm.go
+++ b/gtm.go
@@ -217,7 +217,11 @@ func (this *OpBuf) Flush(session *mgo.Session, ctx *OpCtx) {
 				resultId := fmt.Sprintf("%s.%v", n, result["_id"])
 				if mapped, ok := byId[resultId]; ok {
 					for _, o := range mapped {
-						o.Data = result
+						data := make(map[string]interface{})
+						for k, v := range result {
+							data[k] = v
+						}
+						o.Data = data
 					}
 				}
 			}

--- a/gtm.go
+++ b/gtm.go
@@ -215,13 +215,17 @@ func (this *OpBuf) Flush(session *mgo.Session, ctx *OpCtx) {
 		if err == nil {
 			for _, result := range results {
 				resultId := fmt.Sprintf("%s.%v", n, result["_id"])
-				if mapped, ok := byId[resultId]; ok {
-					for _, o := range mapped {
-						data := make(map[string]interface{})
-						for k, v := range result {
-							data[k] = v
+				if ops, ok := byId[resultId]; ok {
+					if len(ops) == 1 {
+						ops[0].Data = result
+					} else {
+						for _, o := range ops {
+							data := make(map[string]interface{})
+							for k, v := range result {
+								data[k] = v
+							}
+							o.Data = data
 						}
-						o.Data = data
 					}
 				}
 			}


### PR DESCRIPTION
Commit avoids race conditions in tools that depend on GTM by copying the
result `map[string]interface{}` into a new data structure. 

By doing so, each op's Data is decoupled from each other and will not run into concurrent read/write failures in the downstream library.

This could be left to downstream libraries to implement but seems preferable to handle here.

Thanks for your continued work on GTM!