### PR TITLE
Keep document for .remove() command

### DIFF
--- a/gtm.go
+++ b/gtm.go
@@ -729,7 +729,7 @@ func (this *Op) ParseLogEntry(entry *OpLog, options *Options) (include bool, err
 				var doc Doc
 				rawField.Unmarshal(&doc)
 				this.Id = doc.Id
-				if this.IsInsert() {
+				if this.IsInsert() || this.IsDelete() {
 					if u, err = options.Unmarshal(this.Namespace, rawField); err == nil {
 						this.processData(u)
 					}


### PR DESCRIPTION
 * to be able to do anything with document when we see `IsDelete()`, like removing it, we would need `_id` at least