### PR TITLE
Fixed shard retrieval

### DIFF
--- a/gtm.go
+++ b/gtm.go
@@ -434,7 +434,7 @@ func (shard *ShardInfo) GetURL() string {
 		// there might be multiple comma-separated hosts.
 		// for now, we just take the first one and ignore the rest.
 		hosts := strings.Split(hostParts[1], ",")
-		return "mongodb://" + hosts[0] + "?replicaSet=" + hostParts[0]
+		return "mongodb://" + hosts[0] + "/?replicaSet=" + hostParts[0]
 	} else {
 		return "mongodb://" + hostParts[0]
 	}

--- a/gtm.go
+++ b/gtm.go
@@ -431,7 +431,10 @@ func (n *N) isCollection() bool {
 func (shard *ShardInfo) GetURL() string {
 	hostParts := strings.SplitN(shard.hostname, "/", 2)
 	if len(hostParts) == 2 {
-		return "mongodb://" + hostParts[1] + "?replicaSet=" + hostParts[0]
+		// there might be multiple comma-separated hosts.
+		// for now, we just take the first one and ignore the rest.
+		hosts := strings.Split(hostParts[1], ",")
+		return "mongodb://" + hosts[0] + "?replicaSet=" + hostParts[0]
 	} else {
 		return "mongodb://" + hostParts[0]
 	}
@@ -1711,7 +1714,7 @@ func GetShards(client *mongo.Client) (shardInfos []*ShardInfo) {
 	// use the hostnames to create multiple clients for a call to StartMulti
 	col := client.Database("config").Collection("shards")
 	opts := &options.FindOptions{}
-	cursor, err := col.Find(context.Background(), nil, opts)
+	cursor, err := col.Find(context.Background(), bson.D{}, opts)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
This fixes 2 problems I've encountered when working with sharded mongodb cluster:

1. `GetShards` function always returned empty results, because a filter query was incorrect (it used `nil` as a filter instead of `bson.D{}`)
2. If there are multiple comma-separated hostnames for different mongodb replicas in each shard, the `GetUrl` function returned invalid URLs. Now it returns a first URL from the comma-separated list, which is imperfect, but at least it works.